### PR TITLE
Use string interpolation over string composition

### DIFF
--- a/ConsoleApp1/Item.cs
+++ b/ConsoleApp1/Item.cs
@@ -9,8 +9,8 @@
 
         public override string ToString()
         {
-            
-            return string.Format("Id:{0}, Name:{1}, Iscompelte:{2}", Id, Name, IsComplete);
+
+            return string.Format($"Id:{Id}, Name:{Name}, Iscompelte:{IsComplete}");
 
         }
 


### PR DESCRIPTION
In this PR:
- [x] Example of using [string interpolation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated)

Rationale: easier to read and less error-prone.